### PR TITLE
Fix travis build

### DIFF
--- a/.Rprofile
+++ b/.Rprofile
@@ -1,4 +1,8 @@
-if (!require("pacman")) install.packages("pacman")
+if (file.exists("~/.Rprofile")) source("~/.Rprofile")
+
+if (interactive()) {
+
+if (!require("pacman")) utils::install.packages("pacman")
 pacman::p_load(qdap, reports)
 
 update_version <- function(ver = NULL){
@@ -8,12 +12,13 @@ update_version <- function(ver = NULL){
     loc <- grep(regex, desc)
     ver <- ifelse(is.null(ver), as.numeric(gsub(regex, "\\2", desc[loc])) + 1, ver)
     desc[loc] <- sprintf(gsub(regex, "\\1%s", desc[loc]), ver)
-    cat(paste(desc, collapse="\n"), file="DESCRIPTION")
+    cat(paste0(paste(desc, collapse="\n"), "\n"), file="DESCRIPTION")
 
     cit <- suppressWarnings(readLines("inst/CITATION"))
     regex2 <- '(version\\s+\\d+\\.\\d+\\.)(\\d+)([."])'
     cit <- paste(cit, collapse="\n")
-    cat(gsub(regex2, paste0("\\1", ver, "\\3"), cit), file = "inst/CITATION")
+    cat(paste0(gsub(regex2, paste0("\\1", ver, "\\3"), cit), "\n"),
+        file = "inst/CITATION")
     message(sprintf("Updated to version: %s", ver))
 }
 
@@ -102,9 +107,9 @@ md_toc <- function(path = "README.md", repo = basename(getwd()),
 
     beg <- grep("^You are welcome", x)
     end <- grep("compose a friendly", x)
-    
+
     x[beg] <- sprintf(contact, repo, repo)
-    
+
     x <- x[!seq_along(x) %in% (1+beg:end)]
 
     a <- grep("<table>", x)
@@ -125,6 +130,6 @@ contact <- paste(c(
     "- send a pull request on: <https://github.com/trinker/%s/>    ",
     "- compose a friendly e-mail to: <tyler.rinker@gmail.com>    "
 ), collapse="\n")
-    
-    
-    
+
+
+}# end if (interactive())

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,20 @@
-language: java
+language: r
+sudo: false
+cache: packages
+pandoc: false
 
-sudo: required
-before_install:
-  - curl -OL http://raw.github.com/craigcitro/r-travis/master/scripts/travis-tool.sh
-  - chmod 755 ./travis-tool.sh
-  - ./travis-tool.sh bootstrap
-install:
-  - sh -e /etc/init.d/xvfb start
-  - sudo R CMD javareconf
-  - ./travis-tool.sh install_github hadley/devtools
-  - ./travis-tool.sh install_deps
-  - sudo apt-get install ffmpeg
-script: ./travis-tool.sh run_tests
+r:
+  - 3.1
+  - oldrel
+  - release
+  - devel
+
+addons:
+  apt:
+    packages:
+      - ghostscript
+
 notifications:
   email:
     on_success: change
     on_failure: change
-
-env:
-  global:
-    - R_BUILD_ARGS="--resave-data=best" 
-    - DISPLAY=:99.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: plotflow
 Type: Package
 Title: Tools to Speed Up Workflow Associated with Plotting
-Version: 0.2.0
-Date: 2017-12-01
+Version: 0.2.1
+Date: 2017-12-05
 Author: Tyler Rinker, Ananda Mahto, Mikko Korpela
 Maintainer: Tyler Rinker <tyler.rinker@gmail.com>
 Description: Plotting functions not found in other plotting packages.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# plotflow 0.2.1
+
+* Fixed a bug introduced in 0.2.0 where the package only worked on Windows
+
 # plotflow 0.2.0
 
 * Package was updated for compatibility with ggplot2 >= 2.2.0 (now required).

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You can, however, download the [zip ball](https://github.com/trinker/plotflow/zi
 # install.packages("devtools")
 
 library(devtools)
-install_github("plotflow", "trinker")
+install_github("trinker/plotflow")
 ```
 
 ## Installing Ghostscript

--- a/inst/CITATION
+++ b/inst/CITATION
@@ -6,11 +6,11 @@ citEntry(entry = "manual",
     author = "Tyler W. Rinker",
     organization = "University at Buffalo/SUNY",
     address = "Buffalo, New York",
-    note = "version 0.2.0",
+    note = "version 0.2.1",
     year = "2017",
     url = "http://github.com/trinker/plotflow",
     textVersion  = paste("Rinker, T. W. (2017).",
         "plotflow: Tools to speed up workflow associated with plotting",
-        "version 0.2.0. University at Buffalo. Buffalo, New York.",
+        "version 0.2.1. University at Buffalo. Buffalo, New York.",
         "http://github.com/trinker/plotflow")
 )


### PR DESCRIPTION
See commit-specific comments, and

* Added trailing newlines to the output of `update_version()`
* In `.Rprofile`, use `utils::install.packages()` instead of just `install.packages()`, because only the `"base"` package is loaded when processing `.Rprofile`.
* Travis (as it is not running on Windows) will not be able to build the package until my previous pull request (the importFrom patch) or equivalent is applied. Sorry about that.